### PR TITLE
fix: add desktop to plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,7 @@ apps:
     plugs:
       - home
       - network
+      - desktop
 
 parts:
   jira-cli:


### PR DESCRIPTION
Opening URLs through xdg-open in a confined snap requires the desktop plug, otherwise this will be blocked by apparmor. jira-cli uses this functionality when browsing an issue list and pressing "Enter" .